### PR TITLE
Enable show details option on getnewaddress

### DIFF
--- a/green_cli/green.py
+++ b/green_cli/green.py
@@ -478,6 +478,16 @@ def getnewaddress(session, details):
     return _gdk_resolve(auth_handler)["address"]
 
 @green.command()
+@click.option('--subaccount', default=0, expose_value=False, callback=details_json)
+@click.option('--address_type', default="", expose_value=False, callback=details_json)
+@with_login
+@print_result
+@gdk_resolve
+def getreceiveaddress(session, details):
+    """Get a new receive address"""
+    return gdk.get_receive_address(session.session_obj, json.dumps(details))
+
+@green.command()
 @with_login
 @print_result
 def getfeeestimates(session):


### PR DESCRIPTION
Currently getnewaddress only returns the confidential address whereas functions that return transaction data only show unconfidential address. In order for a user to map the two they can use the pointer and sub account to identify addresses and check for confirmation etc. This can't be done at the moment as getnewaddress does not return such information.

This pull request adds an optional flag to allow the entire json results to be shown with the new address call.

If confidential address is later added to the data returned by green when calling getnewaddress the user won't have to use pointer to map the two, until then they can using this change.