### PR TITLE
authenticator: wally: use address_type to determine if is segwit

### DIFF
--- a/green_cli/authenticators/wally.py
+++ b/green_cli/authenticators/wally.py
@@ -110,7 +110,7 @@ class WallyAuthenticator(MnemonicOnDisk, HardwareDevice):
         signatures = []
         signer_commitments = []
         for index, utxo in enumerate(utxos):
-            is_segwit = utxo['script_type'] in [14, 15, 159, 162] # FIXME!!
+            is_segwit = utxo['address_type'] in ['p2wsh', 'csv']
             if not is_segwit:
                 # FIXME
                 raise NotImplementedError("Non-segwit input")


### PR DESCRIPTION
For consistency on the usage of the hww interface, and because
script_type is Green specific.