### PR TITLE
Support greedy addressees

### DIFF
--- a/green_cli/param_types.py
+++ b/green_cli/param_types.py
@@ -32,6 +32,9 @@ class Amount(click.ParamType):
             # level. gdk only allows one addressee with send all
             ctx.params['details']['send_all'] = True
             value = 0
+        elif value == '0':
+            ctx.params['details']['addressees'][-1]['greedy'] = True
+            value = 0
         else:
             value = self.value2sat(value)
 

--- a/green_cli/tx.py
+++ b/green_cli/tx.py
@@ -175,7 +175,7 @@ def outputs(ctx, session, **options):
 
 @outputs.command(name='add')
 @click.argument('address', type=Address(), expose_value=False)
-@click.argument('amount', type=Amount(), expose_value=False)
+@click.argument('amount', type=Amount(), default='0', expose_value=False)
 @with_login
 def add_outputs(session, details):
     """Add a transaction output."""


### PR DESCRIPTION
Adding an output without specifying an amount results in a 'greedy'
output which consumes all remaining coins.

For example:

$ green-cli tx outputs add $ADDR