### PR TITLE
jade: Update to reflect rename of tx output public blinding key

### DIFF
--- a/green_cli/authenticators/jade.py
+++ b/green_cli/authenticators/jade.py
@@ -278,7 +278,7 @@ class JadeAuthenticatorLiquid(JadeAuthenticator):
             custom_vbf)
 
         # Add the script blinding key and return
-        commitments['blinding_key'] = bytes.fromhex(output['public_key'])
+        commitments['blinding_key'] = bytes.fromhex(output['blinding_key'])
         return commitments
 
     # Poke the blinding factors and commitments into the results structure


### PR DESCRIPTION
Following gdk commit [8bd193c0](https://github.com/Blockstream/gdk/commit/8bd193c0884378e9ff2ad1ef9aededef14b84024)