### PR TITLE
signmessage: fixes for hww

### DIFF
--- a/green_cli/authenticators/hardware.py
+++ b/green_cli/authenticators/hardware.py
@@ -50,10 +50,15 @@ class HWIDevice(HardwareDevice):
 
         signature = hwilib.commands.signmessage(self._device, message, path)['signature']
         signature = base64.b64decode(signature)
-        if len(signature) == wally.EC_SIGNATURE_RECOVERABLE_LEN:
-            signature = signature[1:]
 
-        return {'signature': wally.ec_sig_to_der(signature).hex()}
+        if details['create_recoverable_sig']:
+            sig_hex = signature.hex()
+        else:
+            if len(signature) == wally.EC_SIGNATURE_RECOVERABLE_LEN:
+                signature = signature[1:]
+            sig_hex = wally.ec_sig_to_der(signature).hex()
+
+        return {'signature': sig_hex}
 
     def sign_tx(self, details: Dict):
         raise NotImplementedError("hwi sign tx not implemented")

--- a/green_cli/authenticators/jade.py
+++ b/green_cli/authenticators/jade.py
@@ -178,12 +178,15 @@ class JadeAuthenticator(MnemonicOnDisk, HardwareDevice):
 
         sig_decoded = base64.b64decode(sig_encoded)
 
-        # Need to truncate lead byte if recoverable signature
-        if len(sig_decoded) == wally.EC_SIGNATURE_RECOVERABLE_LEN:
-            sig_decoded = sig_decoded[1:]
+        if details['create_recoverable_sig'] and not details['use_ae_protocol']:
+            sig_hex = sig_decoded.hex()
+        else:
+            # Need to truncate lead byte if recoverable signature
+            if len(sig_decoded) == wally.EC_SIGNATURE_RECOVERABLE_LEN:
+                sig_decoded = sig_decoded[1:]
+            sig_hex = wally.ec_sig_to_der(sig_decoded).hex()
 
-        der_sig = wally.ec_sig_to_der(sig_decoded)
-        result['signature'] = der_sig.hex()
+        result['signature'] = sig_hex
         return result
 
     @classmethod


### PR DESCRIPTION
If `recoverable` is `True`, the authenticator is supposed to return a 65 bytes recoverable signature in hex, not the DER signature encoded in hex.

Things get a bit more complicated with anti-exfil support.