### PR TITLE
develop branch updates

### DIFF
--- a/green_cli/common.py
+++ b/green_cli/common.py
@@ -226,6 +226,15 @@ def updatesubaccount(session, details):
 
 @green.command()
 @with_login
+@print_result
+@with_gdk_resolve
+@click.option('--action', expose_value=False, callback=details_json)
+@click.option('--data-source', expose_value=False, callback=details_json)
+def cachecontrol(session, details):
+    return gdk.cache_control(session.session_obj, json.dumps(details))
+
+@green.command()
+@with_login
 @click.argument('pin')
 @click.argument('device_id')
 def setpin(session, pin, device_id):

--- a/green_cli/common.py
+++ b/green_cli/common.py
@@ -210,15 +210,15 @@ def getsubaccounts(session, details):
 @with_login
 @print_result
 @with_gdk_resolve
-@click.argument('pointer', type=int)
-def getsubaccount(session, pointer):
+@click.argument('subaccount', type=int)
+def getsubaccount(session, subaccount):
     """Show details of specific subaccount."""
-    return gdk.get_subaccount(session.session_obj, pointer)
+    return gdk.get_subaccount(session.session_obj, subaccount)
 
 @green.command()
 @with_login
 @with_gdk_resolve
-@click.option('--subaccount', default=0, expose_value=False, callback=details_json)
+@click.argument('subaccount', type=int, expose_value=False, callback=details_json)
 @click.option('--name', expose_value=False, callback=details_json)
 @click.option('--hidden', type=bool, expose_value=False, callback=details_json)
 def updatesubaccount(session, details):

--- a/green_cli/common.py
+++ b/green_cli/common.py
@@ -290,11 +290,9 @@ def setcsvtime(session, details):
 @with_login
 @click.argument('txid', type=str)
 @click.argument('memo', type=str)
-@click.option('--bip70', is_flag=True, help='Set a bip70 memo')
-def settransactionmemo(session, txid, memo, bip70):
+def settransactionmemo(session, txid, memo):
     """Set a memo on a wallet transaction."""
-    memo_type = gdk.GA_MEMO_BIP70 if bip70 else gdk.GA_MEMO_USER
-    return gdk.set_transaction_memo(session.session_obj, txid, memo, memo_type)
+    return gdk.set_transaction_memo(session.session_obj, txid, memo, gdk.GA_MEMO_USER)
 
 @green.command()
 @with_login


### PR DESCRIPTION
Updates to the develop branch for further gdk changes:

 - `getsubaccount`/`updatesubaccount`: make subaccount an argument for consistency
 - `settransactionmemo`: remove bip70 flag
 -  expose the new `cachecontrol` command
